### PR TITLE
Ensure `this` is defined

### DIFF
--- a/lib/sites.js
+++ b/lib/sites.js
@@ -3,8 +3,10 @@ function Sites( api ) {
 }
 
 Sites.prototype.query = function( args ) {
+	var self = this;
+
 	return new Promise( function( resolve, reject ) {
-		this.api
+		self.api
 			.get( '/sites' )
 			.query( args )
 			.end( function( err, res ) {


### PR DESCRIPTION
The switch away from arrow functions in e7aec8a1a55ac863b1d0c1b659938d9ba71f187c led to "Cannot read property 'get' of undefined" errors.

Props to @nickdaugherty for spotting this.