### PR TITLE
Add sitemeta helper

### DIFF
--- a/lib/sites.js
+++ b/lib/sites.js
@@ -27,10 +27,16 @@ Sites.prototype.getMeta = function( site_id, meta_key ) {
 			.get( '/sites/' + site_id + '/meta/' + meta_key )
 			.end( function( err, res ) {
 				if ( err ) {
+					// Meta doesn't exist, but that shouldn't trigger an error
+					if ( 404 === err.status ) {
+						return resolve( null );
+					}
+
 					return reject( err );
 				}
 
-				return resolve( res.body );
+				// Meta keys are unique per site
+				return resolve( res.body.data[0].meta_value );
 			});
 	});
 }

--- a/lib/sites.js
+++ b/lib/sites.js
@@ -20,15 +20,15 @@ Sites.prototype.query = function( args ) {
 Sites.prototype.getMeta = function( site_id, meta_key ) {
 	var self = this;
 
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( function( resolve, reject ) {
 		self.api
-		.get( '/sites/' + site_id + '/meta/' + meta_key )
-		.end( ( err, res ) => {
-			if ( err ) {
-				return reject( err );
-			}
+			.get( '/sites/' + site_id + '/meta/' + meta_key )
+			.end( function( err, res ) {
+				if ( err ) {
+					return reject( err );
+				}
 
-			return resolve( res.body );
+				return resolve( res.body );
 			});
 	});
 }

--- a/lib/sites.js
+++ b/lib/sites.js
@@ -18,8 +18,10 @@ Sites.prototype.query = function( args ) {
 }
 
 Sites.prototype.getMeta = function( site_id, meta_key ) {
+	var self = this;
+
 	return new Promise( ( resolve, reject ) => {
-		this.api
+		self.api
 		.get( '/sites/' + site_id + '/meta/' + meta_key )
 		.end( ( err, res ) => {
 			if ( err ) {

--- a/lib/sites.js
+++ b/lib/sites.js
@@ -17,4 +17,19 @@ Sites.prototype.query = function( args ) {
 	});
 }
 
+Sites.prototype.getMeta = function( site_id, meta_key ) {
+	return new Promise( ( resolve, reject ) => {
+		this.api
+		.get( '/sites/' + site_id + '/meta/' + meta_key )
+		.end( ( err, res ) => {
+			if ( err ) {
+				return reject( err );
+			}
+
+			return resolve( res.body );
+			});
+	});
+}
+
+
 module.exports = Sites;


### PR DESCRIPTION
To support the Cron Control monitor in the crontab app (https://github.com/Automattic/vip-go-crontab/pull/13), it's necessary to retrieve several pieces of sitemeta, including whether or not the site uses Basic Auth.