### PR TITLE
Add support for querying software stacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ function WPCOM_VIP( token ) {
 
     var sites = require( './lib/sites' );
     this.sites = new sites( this );
+
+    var softwareStacks = require( './lib/software-stacks' );
+    this.softwareStacks = new softwareStacks( this );
 }
 
 WPCOM_VIP.prototype.API_URL     = 'https://api.vipv2.net';
@@ -49,7 +52,7 @@ WPCOM_VIP.prototype.currentUserCan = function( cap, action ) {
     if ( ! Array.isArray( this.caps ) ) {
         return false;
     }
-    
+
     return this.caps.some( function( c ) {
         if ( c.resource_name == cap ) {
             return action <= c.permissions;

--- a/lib/software-stacks.js
+++ b/lib/software-stacks.js
@@ -1,0 +1,22 @@
+function SoftwareStacks( api ) {
+	this.api = api;
+}
+
+SoftwareStacks.prototype.query = function( args ) {
+	var self = this;
+
+	return new Promise( function( resolve, reject ) {
+		self.api
+			.get( '/software_stacks' )
+			.query( args )
+			.end( function( err, res ) {
+				if ( err ) {
+					return reject( err );
+				}
+
+				return resolve( res.body );
+			});
+	});
+}
+
+module.exports = SoftwareStacks;


### PR DESCRIPTION
To allow the cron monitor (https://github.com/Automattic/vip-go-crontab/pull/13) to query for sites by WP version (to exclude non-WP sites), access to the software-stacks endpoint is needed. Currently, the WP version is hardcoded, which is #suboptimal.