### PR TITLE
Don't set headers to undefined or null

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -10,6 +10,10 @@ Request.prototype.addAuthorization = function( request ) {
     if ( ! this.wpcomVIP || ! this.wpcomVIP.auth ) {
         return request;
     }
+	
+    if ( ! this.wpcomVIP.auth.apiUserId || ! this.wpcomVIP.auth.token ) {
+        return request;
+    }
 
     return request
         .set( 'API-User-ID', this.wpcomVIP.auth.apiUserId )


### PR DESCRIPTION
If we don't have user ID or access token values, don't try to set those headers.