### PR TITLE
add support for PATCH API requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ WPCOM_VIP.prototype.put = function() {
 	return this.req.put.apply( this.req, arguments );
 };
 
+WPCOM_VIP.prototype.patch = function() {
+	return this.req.patch.apply( this.req, arguments );
+};
+
 WPCOM_VIP.prototype.del = function() {
 	return this.req.del.apply( this.req, arguments );
 };

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -58,6 +58,20 @@ Request.prototype.put = function( url ) {
 	return this.addAuthorization( request );
 };
 
+Request.prototype.patch = function( url ) {
+	url = this.makeUrl( url );
+
+	let request = superagent
+		.patch( url )
+		.timeout( this.wpcomVIP.API_TIMEOUT );
+
+	if ( this.wpcomVIP.proxy ) {
+		request = request.proxy( this.wpcomVIP.proxy );
+	}
+
+	return this.addAuthorization( request );
+};
+
 Request.prototype.del = function( url ) {
 	url = this.makeUrl( url );
 


### PR DESCRIPTION
## Description

A new PATCH API has been added to GOOP to update notification subscriptions. This would be called from Parker during the `updateNotificationSubscription` mutation. This requires that the VIP JS SDK support making request to PATCH APIs.

## Links
#### PATCH API in GOOP
- [Code](https://github.com/Automattic/vip-go-api/blob/f8fe5bbd9e4c5c89fde9d00187b3f58080dccda1/src/notifications/subscriptions/notification-subscriptions.controller.ts#L80-L87)
- [API Doc](https://api.vipv2.net/docs#/Notifications/NotificationSubscriptionsController_updateById)
- [PR](https://github.com/Automattic/vip-go-api/pull/4354) which introduced support for PATCH APIs in GOOP (contains some discussion around it in comments).
